### PR TITLE
Fix indent in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,14 @@ def makebin():
 makebin()
 
 setup(
-	name="psdwatcher",
-	author=__author__,
-	version=__version__,
-	license=open("LICENSE").read(),
+    name="psdwatcher",
+    author=__author__,
+    version=__version__,
+    license=open("LICENSE").read(),
     url="https://github.com/alice1017/psdwatcher",
-	description="You can watch the change log of psd file using git",
+    description="You can watch the change log of psd file using git",
     long_description=open("README.rst").read(),
-	requires=['termcolor'],
-	scripts=['bin/psdwatcher']
+    requires=['termcolor'],
+    scripts=['bin/psdwatcher']
 )
 


### PR DESCRIPTION
setup.pyでインデントでタブが混ざっていたので、全てスペース4つに変更してみました。

追伸
素晴らしいプログラムの作成ありがとうございます:blush:
私の職場でもGitでクリエイティブを管理しようということになりました。
